### PR TITLE
Fix all the clippy lints, bring the crate up to date, fix two bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "akaze"
 version = "0.1.0"
+edition = "2018"
 authors = ["John Stalbaum <indianajohn@github>"]
 description = "A Rust implementation of the A-KAZE algorithm."
 homepage = "https://github.com/indianajohn/akaze-rust/"
@@ -9,7 +10,6 @@ readme = "README.md"
 keywords = ["CV", "vision", "sfm", "features", "descriptors"]
 categories = ["science::robotics", "multimedia::images"]
 license = "MIT"
-license-file = "README.md"
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ clap = "2.32.0"
 
 [profile.release]
 codegen-units = 1
+
+[dev-dependencies]
+approx = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ serde_derive = "1.0.79"
 tempdir = "0.3.7"
 nalgebra = "0.16.4"
 clap = "2.32.0"
+
+[profile.release]
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # A-KAZE Feature Detector, Extractor, and Matcher for Rust
-This repository contains a Rust implementation of the A-KAZE algorithm. I would like to 
-thank the original authors of the A-KAZE algorithm, who provided the 
+
+This repository contains a Rust implementation of the A-KAZE algorithm. I would like to
+thank the original authors of the A-KAZE algorithm, who provided the
 implementation I used as a reference here:
 
 [A-KAZE original authors' GitHub repository](https://github.com/pablofdezalc/akaze)
@@ -12,14 +13,16 @@ Fast Explicit Diffusion for Accelerated Features in Nonlinear Scale Spaces. Pabl
 KAZE Features. Pablo F. Alcantarilla, Adrien Bartoli and Andrew J. Davison. In European Conference on Computer Vision (ECCV), Fiorenze, Italy, October 2012
 
 In case you found this elsewhere, this code lives here:
-https://github.com/indianajohn/akaze-rust/
+<https://github.com/indianajohn/akaze-rust/>
 
 ## Summary
+
 The algorithm used here was heavily inspired by that repository, but differs in places. The
 resulting implementation produces results very similar to the original code, albeit a bit
 more slowly. The code in this crate is 100% `safe` Rust, as are most of the dependencies.
 
 ## Results
+
 This crate can be used to extract keypoints and descriptors from an image using
 a non-linear scale space.
 ![Keypoints](/test-data/keypoints-1.jpg "A-KAZE keypoints")
@@ -29,6 +32,7 @@ It also includes a function to do matching with the 8-point algorithm.
 ![Matches](/test-data/match_image.jpg "A-AKAZE matches")
 
 ## Example
+
 ```rust
  extern crate akaze;
  use std::path::Path;
@@ -48,11 +52,12 @@ println!("Got {} matches.", matches.len());
 ```
 
 ## Running Demonstrations
-```
+
+```bash
 # All executables (and your code probably) should be run in release mode, otherwise
 # these can be quite slow.
 # Extraction
-cargo run --release --bin extract_features -- ./test-data/2.jpg ./output.cbor 
+cargo run --release --bin extract_features -- ./test-data/2.jpg ./output.cbor
 
 # Matching
 cargo run --release --bin extract_and_match -- -m ./match_image.png ./test-data/1.jpg ./test-data/2.jpg
@@ -62,9 +67,11 @@ cargo run --release --bin extract_features -- ./test-data/2.jpg ./output.cbor  -
 ```
 
 ## License
+
 This code is released under the MIT license. See LICENSE.md for more details. You're free to
 use this however you'd like.
 
 ## Disclaimer
+
 I chose to do this project to learn Rust. It's entirely possible this code does not follow
 what some would consider the best Rust style. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ println!("Got {} matches.", matches.len());
 cargo run --release --bin extract_features -- ./test-data/2.jpg ./output.cbor
 
 # Matching
-cargo run --release --bin extract_and_match -- -m ./match_image.png ./test-data/1.jpg ./test-data/2.jpg
+cargo run --release --bin extract_and_match -- -m ./match_image.png ./test-data/1.jpg ./test-data/2.jpg testname
 
 # Visualizing scale space
 cargo run --release --bin extract_features -- ./test-data/2.jpg ./output.cbor  -d ./scale-space/

--- a/src/bin/extract_and_match.rs
+++ b/src/bin/extract_and_match.rs
@@ -104,10 +104,10 @@ fn main() {
     match matches.value_of("match_image_path") {
         Some(match_image_path) => {
             info!("Writing scale space since --debug_path/-d option was specified.");
-            let mut input_image_0 = image::open(Path::new(input_path_0).to_owned())
+            let input_image_0 = image::open(Path::new(input_path_0).to_owned())
                 .unwrap()
                 .to_rgb();
-            let mut input_image_1 = image::open(Path::new(input_path_1).to_owned())
+            let input_image_1 = image::open(Path::new(input_path_1).to_owned())
                 .unwrap()
                 .to_rgb();
             let matches_image = feature_match::draw_matches(

--- a/src/bin/extract_features.rs
+++ b/src/bin/extract_features.rs
@@ -67,14 +67,14 @@ fn main() {
         Some(options_path) => {
             if Path::new(options_path).exists() {
                 info!("Reading options file from {}", options_path);
-                let mut file = File::open(options_path.clone()).unwrap();
+                let mut file = File::open(options_path).unwrap();
                 let mut buffer = String::new();
                 file.read_to_string(&mut buffer).unwrap();
                 options = serde_json::from_str(&buffer).unwrap();
             } else {
-                let mut file = File::create(options_path.clone()).unwrap();
+                let mut file = File::create(options_path).unwrap();
                 let serialized = serde_json::to_string(&options).unwrap();
-                file.write(serialized.as_bytes()).unwrap();
+                file.write_all(serialized.as_bytes()).unwrap();
                 info!("Writing options file from {}", options_path);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,11 @@ use time::PreciseTime;
 
 pub mod ops;
 pub mod types;
-use ops::estimate_fundamental_matrix::remove_outliers;
-use types::evolution::{Config, EvolutionStep};
-use types::feature_match::Match;
-use types::image::{gaussian_blur, GrayFloatImage, ImageFunctions};
-use types::keypoint::{Descriptor, Keypoint};
+use crate::ops::estimate_fundamental_matrix::remove_outliers;
+use crate::types::evolution::{Config, EvolutionStep};
+use crate::types::feature_match::Match;
+use crate::types::image::{gaussian_blur, GrayFloatImage, ImageFunctions};
+use crate::types::keypoint::{Descriptor, Keypoint};
 
 /// This function computes the Perona and Malik conductivity coefficient g2
 /// g2 = 1 / (1 + dL^2 / k^2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ fn pm_g2(Lx: &GrayFloatImage, Ly: &GrayFloatImage, k: f64) -> GrayFloatImage {
     let inverse_k: f64 = 1.0f64 / (k * k);
     for y in 0..Lx.height() {
         for x in 0..Lx.width() {
-            let Lx_pixel: f64 = Lx.get(x, y) as f64;
-            let Ly_pixel: f64 = Ly.get(x, y) as f64;
+            let Lx_pixel: f64 = f64::from(Lx.get(x, y));
+            let Ly_pixel: f64 = f64::from(Ly.get(x, y));
             let dst_pixel: f64 =
                 1.0f64 / (1.0f64 + inverse_k * (Lx_pixel * Lx_pixel + Ly_pixel * Ly_pixel));
             dst.put(x, y, dst_pixel as f32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ fn create_nonlinear_scale_space(
             let start = PreciseTime::now();
             evolutions[i].Lt = evolutions[i - 1].Lt.half_size();
             debug!("Half-sizing took {}", start.to(PreciseTime::now()));
-            contrast_factor = contrast_factor * 0.75;
+            contrast_factor *= 0.75;
             debug!(
                 "New image size: {}x{}, new contrast factor: {}",
                 evolutions[i].Lt.width(),
@@ -247,28 +247,20 @@ pub fn extract_features(
 /// ```
 ///
 pub fn match_features(
-    keypoints_0: &Vec<Keypoint>,
-    descriptors_0: &Vec<Descriptor>,
-    keypoints_1: &Vec<Keypoint>,
-    descriptors_1: &Vec<Descriptor>,
+    keypoints_0: &[Keypoint],
+    descriptors_0: &[Descriptor],
+    keypoints_1: &[Keypoint],
+    descriptors_1: &[Descriptor],
 ) -> Vec<Match> {
     // 50usize is a level such that no plausible matches will be filtered - effectively
     // turning this off
     let distance_threshold = 50usize;
     // Take all matches that pass Lowe's ratio.
-    let mut output = ops::feature_matching::descriptor_match(
+    let output = ops::feature_matching::descriptor_match(
         &descriptors_0,
         descriptors_1,
         distance_threshold,
         0.7,
     );
-    let inliers = remove_outliers(
-        &keypoints_0,
-        &keypoints_1,
-        &mut output,
-        10000,
-        0.05f32,
-        0.25f32,
-    );
-    inliers
+    remove_outliers(&keypoints_0, &keypoints_1, &output, 10000, 0.05f32, 0.25f32)
 }

--- a/src/ops/contrast_factor.rs
+++ b/src/ops/contrast_factor.rs
@@ -1,7 +1,7 @@
 extern crate image;
-use ops;
-use types::image::gaussian_blur;
-use types::image::{GrayFloatImage, ImageFunctions};
+use crate::ops;
+use crate::types::image::gaussian_blur;
+use crate::types::image::{GrayFloatImage, ImageFunctions};
 
 /// This function computes a good empirical value for the k contrast factor
 /// given an input image, the percentile (0-1), the gradient scale and the

--- a/src/ops/contrast_factor.rs
+++ b/src/ops/contrast_factor.rs
@@ -29,8 +29,8 @@ pub fn compute_contrast_factor(
     let Ly = ops::derivatives::scharr(&gaussian, false, true, 1);
     for y in 1..(gaussian.height() - 1) {
         for x in 1..(gaussian.width() - 1) {
-            let Lx: f64 = Lx.get(x, y) as f64;
-            let Ly: f64 = Ly.get(x, y) as f64;
+            let Lx = f64::from(Lx.get(x, y));
+            let Ly = f64::from(Ly.get(x, y));
             let modg: f64 = f64::sqrt(Lx * Lx + Ly * Ly);
             if modg > hmax {
                 hmax = modg;
@@ -39,13 +39,13 @@ pub fn compute_contrast_factor(
     }
     for y in 1..(gaussian.height() - 1) {
         for x in 1..(gaussian.width() - 1) {
-            let Lx: f64 = Lx.get(x, y) as f64;
-            let Ly: f64 = Ly.get(x, y) as f64;
+            let Lx = f64::from(Lx.get(x, y));
+            let Ly = f64::from(Ly.get(x, y));
             let modg: f64 = f64::sqrt(Lx * Lx + Ly * Ly);
             if modg != 0.0 {
                 let mut bin_number = f64::floor((num_bins as f64) * (modg / hmax)) as usize;
                 if bin_number == num_bins {
-                    bin_number = bin_number - 1;
+                    bin_number -= 1;
                 }
                 histogram[bin_number] += 1f64;
                 num_points += 1f64;
@@ -56,16 +56,16 @@ pub fn compute_contrast_factor(
     let mut k: usize = 0;
     let mut num_elements: usize = 0;
     while num_elements < threshold && k < num_bins {
-        num_elements = num_elements + histogram[k] as usize;
+        num_elements += histogram[k] as usize;
         k += 1;
     }
     debug!(
         "hmax: {}, threshold: {}, num_elements: {}",
         hmax, threshold, num_elements
     );
-    let mut kperc: f64 = 0.03;
     if num_elements >= threshold {
-        kperc = hmax * (k as f64) / (num_bins as f64);
+        hmax * (k as f64) / (num_bins as f64)
+    } else {
+        0.03
     }
-    kperc
 }

--- a/src/ops/derivatives.rs
+++ b/src/ops/derivatives.rs
@@ -91,7 +91,7 @@ fn scharr_main_axis_kernel(scale: u32) -> Vec<f32> {
     let size = 3 + 2 * (scale - 1) as usize;
     debug_assert!(size >= 3);
     let w = 10.0 / 3.0;
-    let norm = 1.0 / (2.0 * (scale as f64) * (w + 2.0));
+    let norm = 1.0 / (2.0 * f64::from(scale) * (w + 2.0));
     let mut kernel = vec![0f32; size];
     kernel[0] = norm as f32;
     kernel[size / 2] = (w * norm) as f32;

--- a/src/ops/derivatives.rs
+++ b/src/ops/derivatives.rs
@@ -1,4 +1,4 @@
-use types::image::{
+use crate::types::image::{
     horizontal_filter, sqrt_squared, vertical_filter, GrayFloatImage, ImageFunctions,
 };
 

--- a/src/ops/derivatives.rs
+++ b/src/ops/derivatives.rs
@@ -5,6 +5,7 @@ use crate::types::image::{
 #[cfg(test)]
 mod tests {
     use super::{scharr_main_axis_kernel, scharr_off_axis_kernel};
+    use approx::relative_eq;
 
     #[test]
     fn scharr_3x3_main_axis_kernel() {
@@ -12,7 +13,7 @@ mod tests {
         let produced_kernel = scharr_main_axis_kernel(1u32);
         assert_eq!(expected_kernel.len(), produced_kernel.len());
         for i in 0..produced_kernel.len() {
-            assert_eq!(expected_kernel[i], produced_kernel[i]);
+            relative_eq!(expected_kernel[i], produced_kernel[i]);
         }
     }
 
@@ -22,7 +23,7 @@ mod tests {
         let produced_kernel = scharr_off_axis_kernel(1u32);
         assert_eq!(expected_kernel.len(), produced_kernel.len());
         for i in 0..produced_kernel.len() {
-            assert_eq!(expected_kernel[i], produced_kernel[i]);
+            relative_eq!(expected_kernel[i], produced_kernel[i]);
         }
     }
 }

--- a/src/ops/descriptors.rs
+++ b/src/ops/descriptors.rs
@@ -82,6 +82,7 @@ fn get_mldb_descriptor(
 }
 
 /// Fill the comparison values for the MLDB rotation invariant descriptor
+#[allow(clippy::too_many_arguments)]
 fn mldb_fill_values(
     values: &mut [f32],
     sample_step: usize,

--- a/src/ops/descriptors.rs
+++ b/src/ops/descriptors.rs
@@ -1,7 +1,7 @@
-use types::evolution::{Config, EvolutionStep};
-use types::image::ImageFunctions;
+use crate::types::evolution::{Config, EvolutionStep};
+use crate::types::image::ImageFunctions;
 
-use types::keypoint::{Descriptor, Keypoint};
+use crate::types::keypoint::{Descriptor, Keypoint};
 
 /// Extract descriptors from keypoints/an evolution
 ///

--- a/src/ops/descriptors.rs
+++ b/src/ops/descriptors.rs
@@ -12,8 +12,8 @@ use crate::types::keypoint::{Descriptor, Keypoint};
 /// # Return value
 /// A vector of descriptors.
 pub fn extract_descriptors(
-    evolutions: &Vec<EvolutionStep>,
-    keypoints: &Vec<Keypoint>,
+    evolutions: &[EvolutionStep],
+    keypoints: &[Keypoint],
     options: Config,
 ) -> Vec<Descriptor> {
     //int t = (6+36+120)*options_.descriptor_channels
@@ -35,7 +35,7 @@ pub fn extract_descriptors(
 /// Binary-based descriptor
 fn get_mldb_descriptor(
     keypoint: &Keypoint,
-    evolutions: &Vec<EvolutionStep>,
+    evolutions: &[EvolutionStep],
     options: Config,
 ) -> Descriptor {
     let t = (6usize + 36usize + 120usize) * options.descriptor_channels;
@@ -55,9 +55,9 @@ fn get_mldb_descriptor(
     let si = f32::sin(keypoint.angle);
     let mut dpos = 0usize;
     let pattern_size = options.descriptor_pattern_size as f32;
-    for lvl in 0..3 {
+    for (lvl, multiplier) in size_mult.iter().enumerate() {
         let val_count = (lvl + 2usize) * (lvl + 2usize);
-        let sample_size = f32::ceil(pattern_size * size_mult[lvl]) as usize;
+        let sample_size = f32::ceil(pattern_size * multiplier) as usize;
         mldb_fill_values(
             &mut values,
             sample_size,
@@ -83,7 +83,7 @@ fn get_mldb_descriptor(
 
 /// Fill the comparison values for the MLDB rotation invariant descriptor
 fn mldb_fill_values(
-    values: &mut Vec<f32>,
+    values: &mut [f32],
     sample_step: usize,
     level: usize,
     xf: f32,
@@ -92,7 +92,7 @@ fn mldb_fill_values(
     si: f32,
     scale: f32,
     options: Config,
-    evolutions: &Vec<EvolutionStep>,
+    evolutions: &[EvolutionStep],
 ) {
     let pattern_size = options.descriptor_pattern_size;
     let nr_channels = options.descriptor_channels;
@@ -145,8 +145,8 @@ fn mldb_fill_values(
 
 /// Do the binary comparisons to obtain the descriptor
 fn mldb_binary_comparisons(
-    values: &Vec<f32>,
-    descriptor: &mut Vec<u8>,
+    values: &[f32],
+    descriptor: &mut [u8],
     count: usize,
     dpos: &mut usize,
     nr_channels: usize,
@@ -155,10 +155,11 @@ fn mldb_binary_comparisons(
         for i in 0..count {
             let ival = values[nr_channels * i + pos];
             for j in (i + 1)..count {
-                let mut res = 0u8;
-                if ival > values[nr_channels * j + pos] {
-                    res = 1u8;
-                }
+                let res = if ival > values[nr_channels * j + pos] {
+                    1u8
+                } else {
+                    0u8
+                };
                 descriptor[*dpos >> 3usize] |= res << (*dpos & 7);
                 *dpos += 1usize;
             }

--- a/src/ops/detector_response.rs
+++ b/src/ops/detector_response.rs
@@ -1,9 +1,9 @@
-use num_cpus;
 use crate::ops::derivatives;
-use scoped_threadpool::Pool;
 use crate::types::evolution::Config;
 use crate::types::evolution::EvolutionStep;
 use crate::types::image::{GrayFloatImage, ImageFunctions};
+use num_cpus;
+use scoped_threadpool::Pool;
 
 fn compute_multiscale_derivatives_for_evolution(evolution: &mut EvolutionStep, sigma_size: u32) {
     evolution.Lx = derivatives::scharr(&evolution.Lsmooth, true, false, sigma_size);
@@ -19,7 +19,7 @@ fn compute_multiscale_derivatives(evolutions: &mut Vec<EvolutionStep>, options: 
     pool.scoped(|scoped| {
         for evolution in evolutions.iter_mut() {
             scoped.execute(move || {
-                let ratio = f64::powf(2.0f64, evolution.octave as f64);
+                let ratio = f64::powf(2.0f64, f64::from(evolution.octave));
                 let sigma_size =
                     f64::round(evolution.esigma * options.derivative_factor / ratio) as u32;
                 compute_multiscale_derivatives_for_evolution(evolution, sigma_size);
@@ -38,7 +38,7 @@ fn compute_multiscale_derivatives(evolutions: &mut Vec<EvolutionStep>, options: 
 pub fn detector_response(evolutions: &mut Vec<EvolutionStep>, options: Config) {
     compute_multiscale_derivatives(evolutions, options);
     for evolution in evolutions.iter_mut() {
-        let ratio = f64::powf(2.0, evolution.octave as f64);
+        let ratio = f64::powf(2.0, f64::from(evolution.octave));
         let sigma_size = f64::round(evolution.esigma * options.derivative_factor / ratio) as u32;
         let sigma_size_quat = sigma_size * sigma_size * sigma_size * sigma_size;
         let mut Lxx_iter = evolution.Lxx.buffer.iter();

--- a/src/ops/detector_response.rs
+++ b/src/ops/detector_response.rs
@@ -1,9 +1,9 @@
 use num_cpus;
-use ops::derivatives;
+use crate::ops::derivatives;
 use scoped_threadpool::Pool;
-use types::evolution::Config;
-use types::evolution::EvolutionStep;
-use types::image::{GrayFloatImage, ImageFunctions};
+use crate::types::evolution::Config;
+use crate::types::evolution::EvolutionStep;
+use crate::types::image::{GrayFloatImage, ImageFunctions};
 
 fn compute_multiscale_derivatives_for_evolution(evolution: &mut EvolutionStep, sigma_size: u32) {
     evolution.Lx = derivatives::scharr(&evolution.Lsmooth, true, false, sigma_size);

--- a/src/ops/estimate_fundamental_matrix.rs
+++ b/src/ops/estimate_fundamental_matrix.rs
@@ -1,10 +1,10 @@
+use crate::types::feature_match::Match;
+use crate::types::keypoint::Keypoint;
 use nalgebra::{DMatrix, Matrix3, Vector3, SVD};
 use random;
 use random::Source;
 use std::collections::HashSet;
 use std::ops::{Index, IndexMut};
-use crate::types::feature_match::Match;
-use crate::types::keypoint::Keypoint;
 
 /// Do singular value decomposition to estimate the fundamental matrix
 /// given a set of 8 prospective inliers.
@@ -15,9 +15,9 @@ use crate::types::keypoint::Keypoint;
 /// # Return value
 /// Optionally, the fundamental matrix, a 3x3 matrix
 pub fn estimate_fundamental_matrix(
-    keypoints_0: &Vec<Keypoint>,
-    keypoints_1: &Vec<Keypoint>,
-    matches: &mut Vec<Match>,
+    keypoints_0: &[Keypoint],
+    keypoints_1: &[Keypoint],
+    matches: &mut [Match],
     epsilon: f32,
 ) -> Option<Matrix3<f32>> {
     debug_assert!(matches.len() == 8);
@@ -97,16 +97,16 @@ fn evaluate_model(fund_mat: Matrix3<f32>, keypoint_0: &Keypoint, keypoint_1: &Ke
 /// The inlier matches. If no model was found, the size
 /// of the vector will be 0.
 pub fn remove_outliers(
-    keypoints_0: &Vec<Keypoint>,
-    keypoints_1: &Vec<Keypoint>,
-    matches: &Vec<Match>,
+    keypoints_0: &[Keypoint],
+    keypoints_1: &[Keypoint],
+    matches: &[Match],
     num_trials: usize,
     epsilon_model: f32,
     epsilon_inlier: f32,
 ) -> Vec<Match> {
     if matches.len() < 8 {
         warn!("Not enough points to do RANSAC.");
-        return matches.clone();
+        return matches.to_vec();
     } else {
         debug!("Removing outliers with RANSAC using fundamental matrix model.");
     }
@@ -125,30 +125,27 @@ pub fn remove_outliers(
         }
 
         // Get a model
-        match estimate_fundamental_matrix(
+        if let Some(model) = estimate_fundamental_matrix(
             &keypoints_0,
             &keypoints_1,
             &mut model_matches,
             epsilon_model,
         ) {
-            Some(model) => {
-                let mut inlier_count = 0;
-                for match_i in matches {
-                    let error_i = evaluate_model(
-                        model,
-                        &keypoints_0[match_i.index_0],
-                        &keypoints_1[match_i.index_1],
-                    );
-                    if error_i < epsilon_inlier {
-                        inlier_count += 1;
-                    }
-                }
-                if inlier_count > max_inlier_count {
-                    max_inlier_count = inlier_count;
-                    final_model = model;
+            let mut inlier_count = 0;
+            for match_i in matches {
+                let error_i = evaluate_model(
+                    model,
+                    &keypoints_0[match_i.index_0],
+                    &keypoints_1[match_i.index_1],
+                );
+                if error_i < epsilon_inlier {
+                    inlier_count += 1;
                 }
             }
-            None => {}
+            if inlier_count > max_inlier_count {
+                max_inlier_count = inlier_count;
+                final_model = model;
+            }
         }
     }
 

--- a/src/ops/estimate_fundamental_matrix.rs
+++ b/src/ops/estimate_fundamental_matrix.rs
@@ -3,8 +3,8 @@ use random;
 use random::Source;
 use std::collections::HashSet;
 use std::ops::{Index, IndexMut};
-use types::feature_match::Match;
-use types::keypoint::Keypoint;
+use crate::types::feature_match::Match;
+use crate::types::keypoint::Keypoint;
 
 /// Do singular value decomposition to estimate the fundamental matrix
 /// given a set of 8 prospective inliers.

--- a/src/ops/feature_matching.rs
+++ b/src/ops/feature_matching.rs
@@ -1,6 +1,6 @@
 use time::PreciseTime;
-use types::feature_match::Match;
-use types::keypoint::Descriptor;
+use crate::types::feature_match::Match;
+use crate::types::keypoint::Descriptor;
 /// Match two sets of keypoints and descriptors. The
 /// Hamming distance is used to match the descriptor sets,
 /// using a brute force algorithm.

--- a/src/ops/feature_matching.rs
+++ b/src/ops/feature_matching.rs
@@ -1,6 +1,6 @@
-use time::PreciseTime;
 use crate::types::feature_match::Match;
 use crate::types::keypoint::Descriptor;
+use time::PreciseTime;
 /// Match two sets of keypoints and descriptors. The
 /// Hamming distance is used to match the descriptor sets,
 /// using a brute force algorithm.
@@ -21,8 +21,8 @@ use crate::types::keypoint::Descriptor;
 /// # Return value
 /// A vector of matches.
 pub fn descriptor_match(
-    descriptors_0: &Vec<Descriptor>,
-    descriptors_1: &Vec<Descriptor>,
+    descriptors_0: &[Descriptor],
+    descriptors_1: &[Descriptor],
     distance_threshold: usize,
     lowes_ratio: f64,
 ) -> Vec<Match> {
@@ -43,10 +43,8 @@ pub fn descriptor_match(
                 second_to_min_distance = min_distance;
                 min_distance = distance;
                 min_j = j;
-            } else {
-                if distance < second_to_min_distance {
-                    second_to_min_distance = distance;
-                }
+            } else if distance < second_to_min_distance {
+                second_to_min_distance = distance;
             }
         }
         // apply thresholding and Lowe's ratio

--- a/src/ops/fed_tau.rs
+++ b/src/ops/fed_tau.rs
@@ -26,7 +26,7 @@ use std::f64::consts::PI;
 #[allow(non_snake_case)]
 pub fn fed_tau_by_process_time(T: f64, M: i32, tau_max: f64, reordering: bool) -> Vec<f64> {
     // All cycles have the same fraction of the stopping time
-    fed_tau_by_cycle_time(T / (M as f64), tau_max, reordering)
+    fed_tau_by_cycle_time(T / f64::from(M), tau_max, reordering)
 }
 
 /// This function allocates an array of the least number of time steps such
@@ -59,10 +59,12 @@ fn fed_tau_by_cycle_time(t: f64, tau_max: f64, reordering: bool) -> Vec<f64> {
 /// # Return value
 /// The vector with the dynamic step sizes
 fn fed_tau_internal(n: usize, scale: f64, tau_max: f64, reordering: bool) -> Vec<f64> {
-    let mut tauh: Vec<f64> = vec![]; // unsorted tauh
-    if reordering {
-        tauh = vec![0f64; n];
-    }
+    let mut tauh = if reordering {
+        vec![0f64; n]
+    } else {
+        // unsorted tauh
+        vec![]
+    };
     if n == 0 {
         vec![]
     } else {
@@ -89,13 +91,13 @@ fn fed_tau_internal(n: usize, scale: f64, tau_max: f64, reordering: bool) -> Vec
                 prime += 1;
             }
             let mut k = 0;
-            for l in 0..n {
+            for t in tau.iter_mut() {
                 let mut index = ((k + 1) * kappa) % prime - 1;
                 while index >= n {
                     k += 1;
                     index = ((k + 1) * kappa) % prime - 1;
                 }
-                tau[l] = tauh[index];
+                *t = tauh[index];
                 k += 1;
             }
         }

--- a/src/ops/nonlinear_diffusion.rs
+++ b/src/ops/nonlinear_diffusion.rs
@@ -1,5 +1,5 @@
-use types::evolution::EvolutionStep;
-use types::image::{GrayFloatImage, ImageFunctions};
+use crate::types::evolution::EvolutionStep;
+use crate::types::image::{GrayFloatImage, ImageFunctions};
 /// This function performs a scalar non-linear diffusion step
 ///
 /// # Arguments

--- a/src/ops/nonlinear_diffusion.rs
+++ b/src/ops/nonlinear_diffusion.rs
@@ -26,7 +26,7 @@ pub fn calculate_step(evolution_step: &mut EvolutionStep, step_size: f64) {
         let mut Ld_yp_i = Ld_yp.nth(w * (y + 1) + 1).unwrap();
 
         let mut Ld_xn = Ld.buffer.iter();
-        let mut Ld_xn_i = Ld_xn.nth(w * y + 0).unwrap();
+        let mut Ld_xn_i = Ld_xn.nth(w * y).unwrap();
 
         let mut Ld_x = Ld.buffer.iter();
         let mut Ld_x_i = Ld_x.nth(w * y + 1).unwrap();
@@ -41,7 +41,7 @@ pub fn calculate_step(evolution_step: &mut EvolutionStep, step_size: f64) {
         let mut c_yp_i = c_yp.nth(w * (y + 1) + 1).unwrap();
 
         let mut c_xn = c.buffer.iter();
-        let mut c_xn_i = c_xn.nth(w * y + 0).unwrap();
+        let mut c_xn_i = c_xn.nth(w * y).unwrap();
 
         let mut c_x = c.buffer.iter();
         let mut c_x_i = c_x.nth(w * y + 1).unwrap();

--- a/src/ops/nonlinear_diffusion.rs
+++ b/src/ops/nonlinear_diffusion.rs
@@ -1,5 +1,6 @@
 use crate::types::evolution::EvolutionStep;
 use crate::types::image::{GrayFloatImage, ImageFunctions};
+use nalgebra::Vector4;
 /// This function performs a scalar non-linear diffusion step
 ///
 /// # Arguments
@@ -73,59 +74,59 @@ pub fn calculate_step(evolution_step: &mut EvolutionStep, step_size: f64) {
     // First row
     for x in 1..(Lstep.width() - 1) {
         let y = 0;
-        let x_pos = eval(c, Ld, x, y, 0, 1, 1, 0, 0, 0, 0, 0);
-        let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, 1, 1, 0);
-        let x_neg = eval(c, Ld, x, y, -1, 0, 0, -1, 0, 0, 0, 0);
+        let x_pos = eval(c, Ld, x, y, [0, 1, 1, 0], [0, 0, 0, 0]);
+        let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, 1, 1, 0]);
+        let x_neg = eval(c, Ld, x, y, [-1, 0, 0, -1], [0, 0, 0, 0]);
         Lstep.put(x, y, 0.5 * (step_size as f32) * (x_pos - x_neg + y_pos));
     }
     {
         let x = 0;
         let y = 0;
-        let x_pos = eval(c, Ld, x, y, 0, 1, 1, 0, 0, 0, 0, 0);
-        let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, 1, 1, 0);
+        let x_pos = eval(c, Ld, x, y, [0, 1, 1, 0], [0, 0, 0, 0]);
+        let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, 1, 1, 0]);
         Lstep.put(x, y, 0.5 * (step_size as f32) * (x_pos + y_pos));
     }
     {
         let x = Lstep.width() - 1;
         let y = 0;
-        let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, 1, 1, 0);
-        let x_neg = eval(c, Ld, x, y, -1, 0, 0, -1, 0, 0, 0, 0);
+        let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, 1, 1, 0]);
+        let x_neg = eval(c, Ld, x, y, [-1, 0, 0, -1], [0, 0, 0, 0]);
         Lstep.put(x, y, 0.5 * (step_size as f32) * (-x_neg + y_pos));
     }
     // Last row
     let y = Lstep.height() - 1;
     for x in 1..(Lstep.width() - 1) {
-        let x_pos = eval(c, Ld, x, y, 0, 1, 1, 0, 0, 0, 0, 0);
-        let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, -1, -1, 0);
-        let x_neg = eval(c, Ld, x, y, -1, 0, 0, -1, 0, 0, 0, 0);
+        let x_pos = eval(c, Ld, x, y, [0, 1, 1, 0], [0, 0, 0, 0]);
+        let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, -1, -1, 0]);
+        let x_neg = eval(c, Ld, x, y, [-1, 0, 0, -1], [0, 0, 0, 0]);
         Lstep.put(x, y, 0.5 * (step_size as f32) * (x_pos - x_neg + y_pos));
     }
     {
         let x = 0;
-        let x_pos = eval(c, Ld, x, y, 0, 1, 1, 0, 0, 0, 0, 0);
-        let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, -1, -1, 0);
+        let x_pos = eval(c, Ld, x, y, [0, 1, 1, 0], [0, 0, 0, 0]);
+        let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, -1, -1, 0]);
         Lstep.put(x, y, 0.5 * (step_size as f32) * (x_pos + y_pos));
     }
     {
         let x = Lstep.width() - 1;
-        let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, -1, -1, 0);
-        let x_neg = eval(c, Ld, x, y, -1, 0, 0, -1, 0, 0, 0, 0);
+        let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, -1, -1, 0]);
+        let x_neg = eval(c, Ld, x, y, [-1, 0, 0, -1], [0, 0, 0, 0]);
         Lstep.put(x, y, 0.5 * (step_size as f32) * (-x_neg + y_pos));
     }
     // First and last columns
     for y in 1..(Lstep.height() - 1) {
         {
             let x = 0;
-            let x_pos = eval(c, Ld, x, y, 0, 1, 1, 0, 0, 0, 0, 0);
-            let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, 1, 1, 0);
-            let y_neg = eval(c, Ld, x, y, 0, 0, 0, 0, -1, 0, 0, -1);
+            let x_pos = eval(c, Ld, x, y, [0, 1, 1, 0], [0, 0, 0, 0]);
+            let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, 1, 1, 0]);
+            let y_neg = eval(c, Ld, x, y, [0, 0, 0, 0], [-1, 0, 0, -1]);
             Lstep.put(x, y, 0.5 * (step_size as f32) * (x_pos + y_pos - y_neg));
         }
         {
             let x = Lstep.width() - 1;
-            let y_pos = eval(c, Ld, x, y, 0, 0, 0, 0, 0, 1, 1, 0);
-            let x_neg = eval(c, Ld, x, y, -1, 0, 0, -1, 0, 0, 0, 0);
-            let y_neg = eval(c, Ld, x, y, 0, 0, 0, 0, -1, 0, 0, -1);
+            let y_pos = eval(c, Ld, x, y, [0, 0, 0, 0], [0, 1, 1, 0]);
+            let x_neg = eval(c, Ld, x, y, [-1, 0, 0, -1], [0, 0, 0, 0]);
+            let y_neg = eval(c, Ld, x, y, [0, 0, 0, 0], [-1, 0, 0, -1]);
             Lstep.put(x, y, 0.5 * (step_size as f32) * (-x_neg + y_pos - y_neg));
         }
     }
@@ -144,32 +145,23 @@ pub fn eval(
     Ld: &GrayFloatImage,
     x: usize,
     y: usize,
-    plus_x_1: i32,
-    plus_x_2: i32,
-    plus_x_3: i32,
-    plus_x_4: i32,
-    plus_y_1: i32,
-    plus_y_2: i32,
-    plus_y_3: i32,
-    plus_y_4: i32,
+    plus_x: impl Into<Vector4<i32>>,
+    plus_y: impl Into<Vector4<i32>>,
 ) -> f32 {
-    let set_x_1 = (x as i32) + plus_x_1;
-    debug_assert!(set_x_1 >= 0);
-    let set_x_2 = (x as i32) + plus_x_2;
-    debug_assert!(set_x_2 >= 0);
-    let set_x_3 = (x as i32) + plus_x_3;
-    debug_assert!(set_x_3 >= 0);
-    let set_x_4 = (x as i32) + plus_x_4;
-    debug_assert!(set_x_4 >= 0);
-    let set_y_1 = (y as i32) + plus_y_1;
-    debug_assert!(set_y_1 >= 0);
-    let set_y_2 = (y as i32) + plus_y_2;
-    debug_assert!(set_y_2 >= 0);
-    let set_y_3 = (y as i32) + plus_y_3;
-    debug_assert!(set_y_3 >= 0);
-    let set_y_4 = (y as i32) + plus_y_4;
-    debug_assert!(set_y_4 >= 0);
+    let plus_x = plus_x.into();
+    let plus_y = plus_y.into();
+    let set_x = plus_x + Vector4::from_element(x as i32);
+    let set_y = plus_y + Vector4::from_element(y as i32);
     // If we access past the upper bounds of image the image class will assert
-    (c.get(set_x_1 as usize, set_y_1 as usize) + c.get(set_x_2 as usize, set_y_2 as usize))
-        * (Ld.get(set_x_3 as usize, set_y_3 as usize) - Ld.get(set_x_4 as usize, set_y_4 as usize))
+    let c_components = set_x
+        .rows_range(0..2)
+        .zip_map(&set_y.rows_range(0..2), |x, y| {
+            c.get(x as usize, y as usize)
+        });
+    let ld_components = set_x
+        .rows_range(2..4)
+        .zip_map(&set_y.rows_range(2..4), |x, y| {
+            Ld.get(x as usize, y as usize)
+        });
+    (c_components[0] + c_components[1]) * (ld_components[0] - ld_components[1])
 }

--- a/src/ops/scale_space_extrema.rs
+++ b/src/ops/scale_space_extrema.rs
@@ -1,8 +1,8 @@
 use nalgebra::{Matrix2, Vector2, LU};
 use std::f32::consts::PI;
-use types::evolution::{Config, EvolutionStep};
-use types::image::ImageFunctions;
-use types::keypoint::Keypoint;
+use crate::types::evolution::{Config, EvolutionStep};
+use crate::types::image::ImageFunctions;
+use crate::types::keypoint::Keypoint;
 
 /// Compute scale space extrema to get the detector response.
 ///

--- a/src/ops/scale_space_extrema.rs
+++ b/src/ops/scale_space_extrema.rs
@@ -152,13 +152,17 @@ fn do_subpixel_refinement(
         let x_m = evolutions[keypoint.class_id].Ldet.get(x - 1, y);
         let y_p = evolutions[keypoint.class_id].Ldet.get(x, y + 1);
         let y_m = evolutions[keypoint.class_id].Ldet.get(x, y - 1);
+        let x_p_y_p = evolutions[keypoint.class_id].Ldet.get(x + 1, y + 1);
+        let x_p_y_m = evolutions[keypoint.class_id].Ldet.get(x + 1, y - 1);
+        let x_m_y_p = evolutions[keypoint.class_id].Ldet.get(x - 1, y + 1);
+        let x_m_y_m = evolutions[keypoint.class_id].Ldet.get(x - 1, y - 1);
         // Derivative
         let d_x = 0.5f32 * (x_p - x_m);
         let d_y = 0.5f32 * (y_p - y_m);
         // Hessian
         let d_xx = x_p + x_m - 2f32 * x_i;
         let d_yy = y_p + y_m - 2f32 * x_i;
-        let d_xy = 0.25f32 * (x_p + x_m) - 0.25f32 * (x_p + x_m);
+        let d_xy = 0.25f32 * (x_p_y_p + x_m_y_m) - 0.25f32 * (x_p_y_m + x_m_y_p);
         let a = Matrix2::new(d_xx, d_xy, d_xy, d_yy);
         let mut b = Vector2::new(-d_x, -d_y);
         let lu = LU::new(a.clone());

--- a/src/ops/scale_space_extrema.rs
+++ b/src/ops/scale_space_extrema.rs
@@ -139,8 +139,8 @@ fn find_scale_space_extrema(evolutions: &mut Vec<EvolutionStep>, options: Config
 /// # Return value
 /// The resulting keypoints.
 fn do_subpixel_refinement(
-    in_keypoints: &Vec<Keypoint>,
-    evolutions: &Vec<EvolutionStep>,
+    in_keypoints: &[Keypoint],
+    evolutions: &[EvolutionStep],
 ) -> Vec<Keypoint> {
     let mut result: Vec<Keypoint> = vec![];
     for keypoint in in_keypoints.iter() {
@@ -270,7 +270,7 @@ static GAUSS25: [[f32; 7usize]; 7usize] = [
 ];
 
 /// Compute the main orientation of the keypoint.
-fn compute_main_orientation(keypoint: &mut Keypoint, evolutions: &Vec<EvolutionStep>) {
+fn compute_main_orientation(keypoint: &mut Keypoint, evolutions: &[EvolutionStep]) {
     let mut res_x: [f32; 109usize] = [0f32; 109usize];
     let mut res_y: [f32; 109usize] = [0f32; 109usize];
     let mut angs: [f32; 109usize] = [0f32; 109usize];
@@ -308,10 +308,8 @@ fn compute_main_orientation(keypoint: &mut Keypoint, evolutions: &Vec<EvolutionS
         ang1 += 0.15f32;
         for k in 0..109 {
             let ang = angs[k];
-            if ang1 < ang2 && ang1 < ang && ang < ang2 {
-                sum_x += res_x[k];
-                sum_y += res_y[k];
-            } else if ang2 < ang1 && ((ang > 0f32 && ang < ang2) || (ang > ang1 && ang < 2.0 * PI))
+            if (ang1 < ang2 && ang1 < ang && ang < ang2)
+                || (ang2 < ang1 && ((ang > 0f32 && ang < ang2) || (ang > ang1 && ang < 2.0 * PI)))
             {
                 sum_x += res_x[k];
                 sum_y += res_y[k];

--- a/src/ops/scale_space_extrema.rs
+++ b/src/ops/scale_space_extrema.rs
@@ -55,8 +55,9 @@ fn find_scale_space_extrema(evolutions: &mut Vec<EvolutionStep>, options: Config
                 let mut is_repeated = false;
                 let mut is_extremum = true;
                 for (k, prev_keypoint) in keypoint_cache.iter().enumerate() {
-                    if ((keypoint.class_id - 1) == prev_keypoint.class_id)
-                        || (keypoint.class_id == prev_keypoint.class_id)
+                    if keypoint.class_id == prev_keypoint.class_id
+                        || (keypoint.class_id != 0
+                            && keypoint.class_id - 1 == prev_keypoint.class_id)
                     {
                         let dist = (keypoint.point.0 * ratio - prev_keypoint.point.0)
                             * (keypoint.point.0 * ratio - prev_keypoint.point.0)

--- a/src/ops/scale_space_extrema.rs
+++ b/src/ops/scale_space_extrema.rs
@@ -1,8 +1,8 @@
-use nalgebra::{Matrix2, Vector2, LU};
-use std::f32::consts::PI;
 use crate::types::evolution::{Config, EvolutionStep};
 use crate::types::image::ImageFunctions;
 use crate::types::keypoint::Keypoint;
+use nalgebra::{Matrix2, Vector2, LU};
+use std::f32::consts::PI;
 
 /// Compute scale space extrema to get the detector response.
 ///
@@ -112,9 +112,8 @@ fn find_scale_space_extrema(evolutions: &mut Vec<EvolutionStep>, options: Config
     for i in 0..keypoint_cache.len() {
         let mut is_repeated = false;
         let kp_i = keypoint_cache[i];
-        for j in i..keypoint_cache.len() {
+        for kp_j in &keypoint_cache[i..] {
             // Compare response with the upper scale
-            let kp_j = keypoint_cache[j];
             if (kp_i.class_id + 1) == kp_j.class_id {
                 let dist = (kp_i.point.0 - kp_j.point.0) * (kp_i.point.0 - kp_j.point.0)
                     + (kp_i.point.1 - kp_j.point.1) * (kp_i.point.1 - kp_j.point.1);
@@ -165,11 +164,11 @@ fn do_subpixel_refinement(
         let d_yy = y_p + y_m - 2f32 * x_i;
         let d_xy = 0.25f32 * (x_p_y_p + x_m_y_m) - 0.25f32 * (x_p_y_m + x_m_y_p);
         let a = Matrix2::new(d_xx, d_xy, d_xy, d_yy);
-        let mut b = Vector2::new(-d_x, -d_y);
-        let lu = LU::new(a.clone());
-        lu.solve(&mut b);
+        let b = Vector2::new(-d_x, -d_y);
+        let lu = LU::new(a);
+        lu.solve(&b);
         if f32::abs(b[0]) <= 1.0 && f32::abs(b[1]) <= 1.0 {
-            let mut keypoint_clone = keypoint.clone();
+            let mut keypoint_clone = *keypoint;
             keypoint_clone.point = ((x as f32) + b[0], (y as f32) + b[1]);
             keypoint_clone.point = (
                 keypoint_clone.point.0 * ratio + 0.5f32 * (ratio - 1f32),
@@ -204,69 +203,70 @@ pub fn detect_keypoints(evolutions: &mut Vec<EvolutionStep>, options: Config) ->
 }
 
 /// A 7x7 Gaussian kernel.
+#[allow(clippy::excessive_precision)]
 static GAUSS25: [[f32; 7usize]; 7usize] = [
     [
-        0.02546481f32,
-        0.02350698f32,
-        0.01849125f32,
-        0.01239505f32,
-        0.00708017f32,
-        0.00344629f32,
-        0.00142946f32,
+        0.0254_6481f32,
+        0.0235_0698f32,
+        0.0184_9125f32,
+        0.0123_9505f32,
+        0.0070_8017f32,
+        0.0034_4629f32,
+        0.0014_2946f32,
     ],
     [
-        0.02350698f32,
-        0.02169968f32,
-        0.01706957f32,
-        0.01144208f32,
-        0.00653582f32,
-        0.00318132f32,
-        0.00131956f32,
+        0.0235_0698f32,
+        0.0216_9968f32,
+        0.0170_6957f32,
+        0.0114_4208f32,
+        0.0065_3582f32,
+        0.0031_8132f32,
+        0.0013_1956f32,
     ],
     [
-        0.01849125f32,
-        0.01706957f32,
-        0.01342740f32,
-        0.00900066f32,
-        0.00514126f32,
-        0.00250252f32,
-        0.00103800f32,
+        0.0184_9125f32,
+        0.0170_6957f32,
+        0.0134_2740f32,
+        0.0090_0066f32,
+        0.0051_4126f32,
+        0.0025_0252f32,
+        0.0010_3800f32,
     ],
     [
-        0.01239505f32,
-        0.01144208f32,
-        0.00900066f32,
-        0.00603332f32,
-        0.00344629f32,
-        0.00167749f32,
-        0.00069579f32,
+        0.0123_9505f32,
+        0.0114_4208f32,
+        0.0090_0066f32,
+        0.0060_3332f32,
+        0.0034_4629f32,
+        0.0016_7749f32,
+        0.0006_9579f32,
     ],
     [
-        0.00708017f32,
-        0.00653582f32,
-        0.00514126f32,
-        0.00344629f32,
-        0.00196855f32,
-        0.00095820f32,
-        0.00039744f32,
+        0.0070_8017f32,
+        0.0065_3582f32,
+        0.0051_4126f32,
+        0.0034_4629f32,
+        0.0019_6855f32,
+        0.0009_5820f32,
+        0.0003_9744f32,
     ],
     [
-        0.00344629f32,
-        0.00318132f32,
-        0.00250252f32,
-        0.00167749f32,
-        0.00095820f32,
-        0.00046640f32,
-        0.00019346f32,
+        0.0034_4629f32,
+        0.0031_8132f32,
+        0.0025_0252f32,
+        0.0016_7749f32,
+        0.0009_5820f32,
+        0.0004_6640f32,
+        0.0001_9346f32,
     ],
     [
-        0.00142946f32,
-        0.00131956f32,
-        0.00103800f32,
-        0.00069579f32,
-        0.00039744f32,
-        0.00019346f32,
-        0.00008024f32,
+        0.0014_2946f32,
+        0.0013_1956f32,
+        0.0010_3800f32,
+        0.0006_9579f32,
+        0.0003_9744f32,
+        0.0001_9346f32,
+        0.0000_8024f32,
     ],
 ];
 
@@ -302,10 +302,11 @@ fn compute_main_orientation(keypoint: &mut Keypoint, evolutions: &[EvolutionStep
     let mut sum_y = 0f32;
     let mut max = 0f32;
     while ang1 < 2.0f32 * PI {
-        let mut ang2 = ang1 + PI / 3.0f32;
-        if ang1 + PI / 3.0f32 > 2.0f32 * PI {
-            ang2 = ang1 - 5.0f32 * PI / 3.0f32;
-        }
+        let ang2 = if ang1 + PI / 3.0f32 > 2.0f32 * PI {
+            ang1 - 5.0f32 * PI / 3.0f32
+        } else {
+            ang1 + PI / 3.0f32
+        };
         ang1 += 0.15f32;
         for k in 0..109 {
             let ang = angs[k];

--- a/src/types/evolution.rs
+++ b/src/types/evolution.rs
@@ -101,7 +101,7 @@ impl EvolutionStep {
         let esigma = options.base_scale_offset
             * f64::powf(
                 2.0f64,
-                (sublevel as f64) / (options.num_sublevels as f64) + (octave as f64),
+                f64::from(sublevel) / f64::from(options.num_sublevels) + f64::from(octave),
             );
         let etime = 0.5 * (esigma * esigma);
         EvolutionStep {
@@ -134,9 +134,9 @@ impl EvolutionStep {
 pub fn allocate_evolutions(width: u32, height: u32, options: Config) -> Vec<EvolutionStep> {
     let mut out_vec: Vec<EvolutionStep> = vec![];
     for i in 0..options.max_octave_evolution {
-        let rfactor = 1.0f64 / f64::powf(2.0f64, i as f64);
-        let level_height = ((height as f64) * rfactor) as u32;
-        let level_width = ((width as f64) * rfactor) as u32;
+        let rfactor = 1.0f64 / f64::powf(2.0f64, f64::from(i));
+        let level_height = (f64::from(height) * rfactor) as u32;
+        let level_width = (f64::from(width) * rfactor) as u32;
         // Smallest possible octave and allow one scale if the image is small
         if (level_width >= 80 && level_height >= 40) || i == 0 {
             for j in 0..options.num_sublevels {
@@ -171,46 +171,46 @@ fn build_path(mut destination_dir: PathBuf, path_label: String, idx: usize) -> P
 /// # Arguments
 /// * `evolutions` - The evolutions to write.
 /// * `destination_dir` - The destination directory.
-pub fn write_evolutions(evolutions: &Vec<EvolutionStep>, destination_dir: PathBuf) {
-    for i in 0..evolutions.len() {
+pub fn write_evolutions(evolutions: &[EvolutionStep], destination_dir: PathBuf) {
+    for (i, evolution) in evolutions.iter().enumerate() {
         save(
-            &evolutions[i].Lt,
+            &evolution.Lt,
             build_path(destination_dir.clone(), "Lt_".to_string(), i),
         );
         save(
-            &evolutions[i].Lsmooth,
+            &evolution.Lsmooth,
             build_path(destination_dir.clone(), "Lsmooth_".to_string(), i),
         );
         save(
-            &evolutions[i].Lx,
+            &evolution.Lx,
             build_path(destination_dir.clone(), "Lx_".to_string(), i),
         );
         save(
-            &evolutions[i].Ly,
+            &evolution.Ly,
             build_path(destination_dir.clone(), "Ly_".to_string(), i),
         );
         save(
-            &evolutions[i].Lxx,
+            &evolution.Lxx,
             build_path(destination_dir.clone(), "Lxx_".to_string(), i),
         );
         save(
-            &evolutions[i].Lyy,
+            &evolution.Lyy,
             build_path(destination_dir.clone(), "Lyy_".to_string(), i),
         );
         save(
-            &evolutions[i].Lxy,
+            &evolution.Lxy,
             build_path(destination_dir.clone(), "Lxy_".to_string(), i),
         );
         save(
-            &evolutions[i].Lflow,
+            &evolution.Lflow,
             build_path(destination_dir.clone(), "Lflow_".to_string(), i),
         );
         save(
-            &evolutions[i].Lstep,
+            &evolution.Lstep,
             build_path(destination_dir.clone(), "Lstep_".to_string(), i),
         );
         save(
-            &evolutions[i].Ldet,
+            &evolution.Ldet,
             build_path(destination_dir.clone(), "Ldet_".to_string(), i),
         );
     }

--- a/src/types/evolution.rs
+++ b/src/types/evolution.rs
@@ -1,8 +1,7 @@
-use ops::fed_tau;
-use std::fmt::Write;
+use crate::ops::fed_tau;
+use crate::types::image::save;
+use crate::types::image::{GrayFloatImage, ImageFunctions};
 use std::path::PathBuf;
-use types::image::save;
-use types::image::{GrayFloatImage, ImageFunctions};
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct Config {

--- a/src/types/evolution.rs
+++ b/src/types/evolution.rs
@@ -99,10 +99,11 @@ impl EvolutionStep {
     /// * `octave` - The target sublevel.
     /// * `options` - The options to use.
     fn new(octave: u32, sublevel: u32, options: Config) -> EvolutionStep {
-        let esigma = options.base_scale_offset * f64::powf(
-            2.0f64,
-            (sublevel as f64) / (options.num_sublevels as f64) + (octave as f64),
-        );
+        let esigma = options.base_scale_offset
+            * f64::powf(
+                2.0f64,
+                (sublevel as f64) / (options.num_sublevels as f64) + (octave as f64),
+            );
         let etime = 0.5 * (esigma * esigma);
         EvolutionStep {
             etime: etime,
@@ -160,8 +161,7 @@ pub fn allocate_evolutions(width: u32, height: u32, options: Config) -> Vec<Evol
 }
 
 fn build_path(mut destination_dir: PathBuf, path_label: String, idx: usize) -> PathBuf {
-    let mut to_write = String::new();
-    write!(to_write, "{}{:05}.png", path_label, idx);
+    let to_write = format!("{}{:05}.png", path_label, idx);
     destination_dir.push(to_write);
     destination_dir.set_extension(".png");
     destination_dir

--- a/src/types/feature_match.rs
+++ b/src/types/feature_match.rs
@@ -2,8 +2,8 @@ use image::RgbImage;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use types::image::{draw_line, random_color};
-use types::keypoint::Keypoint;
+use crate::types::image::{draw_line, random_color};
+use crate::types::keypoint::Keypoint;
 extern crate serde;
 extern crate serde_json;
 

--- a/src/types/feature_match.rs
+++ b/src/types/feature_match.rs
@@ -90,20 +90,20 @@ pub fn draw_matches(
 /// # Arguments
 /// * 'matches' - The matches to serialize.
 /// * `path` - Path to which to write.
-pub fn serialize_to_file(matches: &Vec<Match>, path: PathBuf) {
+pub fn serialize_to_file(matches: &[Match], path: PathBuf) {
     debug!("Writing results to {:?}", path);
     let mut file = File::create(path.clone()).unwrap();
     let extension = path.extension().unwrap();
     if extension == "json" {
         let serialized = serde_json::to_string(&matches).unwrap();
-        file.write(serialized.as_bytes()).unwrap();
+        file.write_all(serialized.as_bytes()).unwrap();
     } else if extension == "cbor" {
         let serialized = serde_cbor::to_vec(&matches).unwrap();
-        file.write(&serialized[..]).unwrap();
+        file.write_all(&serialized[..]).unwrap();
     } else {
         // Default to JSON
         let serialized = serde_json::to_string(&matches).unwrap();
-        file.write(serialized.as_bytes()).unwrap();
+        file.write_all(serialized.as_bytes()).unwrap();
     }
 }
 

--- a/src/types/feature_match.rs
+++ b/src/types/feature_match.rs
@@ -1,9 +1,9 @@
+use crate::types::image::{draw_line, random_color};
+use crate::types::keypoint::Keypoint;
 use image::RgbImage;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use crate::types::image::{draw_line, random_color};
-use crate::types::keypoint::Keypoint;
 extern crate serde;
 extern crate serde_json;
 
@@ -36,9 +36,9 @@ fn map_pixel_in_1(combined_width: f32, x: f32, y: f32) -> (f32, f32) {
 pub fn draw_matches(
     input_image_0: &RgbImage,
     input_image_1: &RgbImage,
-    keypoints_0: &Vec<Keypoint>,
-    keypoints_1: &Vec<Keypoint>,
-    matches: &Vec<Match>,
+    keypoints_0: &[Keypoint],
+    keypoints_1: &[Keypoint],
+    matches: &[Match],
 ) -> RgbImage {
     debug!(
         "Writing match image for two images with sizes {}x{} and {}x{}.",

--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -133,7 +133,7 @@ pub fn create_unit_float_image(input_image: &DynamicImage) -> GrayFloatImage {
         for gray_pixel in gray_image.pixels() {
             let output_ptr = itr_output.next().unwrap();
             let pixel_value: u8 = gray_pixel.channels()[0];
-            *output_ptr = (pixel_value as f32) * 1f32 / 255f32;
+            *output_ptr = f32::from(pixel_value) * 1f32 / 255f32;
         }
     }
     output_image
@@ -188,8 +188,8 @@ pub fn normalize(input_image: &GrayFloatImage) -> GrayFloatImage {
             let p1 = itr1.next().unwrap();
             let p2 = itr2.next().unwrap();
             let mut pixel = *p2;
-            pixel = pixel - min_pixel;
-            pixel = pixel / new_max_pixel;
+            pixel -= min_pixel;
+            pixel /= new_max_pixel;
             *p1 = pixel;
         }
     }
@@ -267,7 +267,7 @@ pub fn fill_border(output: &mut GrayFloatImage, half_width: usize) {
 /// # Return value
 /// The filter result.
 #[inline(always)]
-pub fn horizontal_filter(image: &GrayFloatImage, kernel: &Vec<f32>) -> GrayFloatImage {
+pub fn horizontal_filter(image: &GrayFloatImage, kernel: &[f32]) -> GrayFloatImage {
     // Cannot have an even-sized kernel
     debug_assert!(kernel.len() % 2 == 1);
     let half_width = (kernel.len() / 2) as i32;
@@ -302,7 +302,7 @@ pub fn horizontal_filter(image: &GrayFloatImage, kernel: &Vec<f32>) -> GrayFloat
 /// # Return value
 /// The filter result.
 #[inline(always)]
-pub fn vertical_filter(image: &GrayFloatImage, kernel: &Vec<f32>) -> GrayFloatImage {
+pub fn vertical_filter(image: &GrayFloatImage, kernel: &[f32]) -> GrayFloatImage {
     // Cannot have an even-sized kernel
     debug_assert!(kernel.len() % 2 == 1);
     let half_width = (kernel.len() / 2) as i32;
@@ -400,9 +400,9 @@ pub fn random_color() -> (u8, u8, u8) {
 /// The averaged pixel.
 fn blend(p1: (u8, u8, u8), p2: (u8, u8, u8)) -> (u8, u8, u8) {
     (
-        (((p1.0 as f32) + (p2.0 as f32)) / 2f32) as u8,
-        (((p1.1 as f32) + (p2.1 as f32)) / 2f32) as u8,
-        (((p1.2 as f32) + (p2.2 as f32)) / 2f32) as u8,
+        ((f32::from(p1.0) + f32::from(p2.0)) / 2f32) as u8,
+        ((f32::from(p1.1) + f32::from(p2.1)) / 2f32) as u8,
+        ((f32::from(p1.2) + f32::from(p2.2)) / 2f32) as u8,
     )
 }
 
@@ -487,7 +487,13 @@ mod tests {
         // test against known correct kernel
         let kernel = gaussian_kernel(3.0, 7);
         let known_correct_kernel = vec![
-            0.10628852, 0.14032133, 0.16577007, 0.17524014, 0.16577007, 0.14032133, 0.10628852,
+            0.1062_8852,
+            0.1403_2133,
+            0.1657_7007,
+            0.1752_4014,
+            0.1657_7007,
+            0.1403_2133,
+            0.1062_8852,
         ];
         for it in kernel.iter().zip(known_correct_kernel.iter()) {
             let (i, j) = it;

--- a/src/types/keypoint.rs
+++ b/src/types/keypoint.rs
@@ -4,7 +4,7 @@ use serde_json;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use types::image::{draw_circle, random_color};
+use crate::types::image::{draw_circle, random_color};
 
 /// A point of interest in an image.
 /// This pretty much follows from OpenCV conventions.

--- a/src/types/keypoint.rs
+++ b/src/types/keypoint.rs
@@ -83,24 +83,24 @@ pub fn draw_keypoints(input_image: &DynamicImage, keypoints: &Vec<Keypoint>) -> 
 ///                   panic if the size of this vector is not equal to the
 ///                   size of the keypoints, or 0.
 /// * `path` - Path to which to write.
-pub fn serialize_to_file(keypoints: &Vec<Keypoint>, descriptors: &Vec<Descriptor>, path: PathBuf) {
+pub fn serialize_to_file(keypoints: &[Keypoint], descriptors: &[Descriptor], path: PathBuf) {
     debug!("Writing results to {:?}", path);
     let mut file = File::create(path.clone()).unwrap();
     let extension = path.extension().unwrap();
     let output = Results {
-        keypoints: keypoints.clone(),
-        descriptors: descriptors.clone(),
+        keypoints: keypoints.to_vec(),
+        descriptors: descriptors.to_vec(),
     };
     if extension == "json" {
         let serialized = serde_json::to_string(&output).unwrap();
-        file.write(serialized.as_bytes()).unwrap();
+        file.write_all(serialized.as_bytes()).unwrap();
     } else if extension == "cbor" {
         let serialized = serde_cbor::to_vec(&output).unwrap();
-        file.write(&serialized[..]).unwrap();
+        file.write_all(&serialized[..]).unwrap();
     } else {
         // Default to JSON
         let serialized = serde_json::to_string(&output).unwrap();
-        file.write(serialized.as_bytes()).unwrap();
+        file.write_all(serialized.as_bytes()).unwrap();
     }
 }
 

--- a/src/types/keypoint.rs
+++ b/src/types/keypoint.rs
@@ -1,10 +1,10 @@
+use crate::types::image::{draw_circle, random_color};
 use image::{DynamicImage, RgbImage};
 use serde_cbor;
 use serde_json;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use crate::types::image::{draw_circle, random_color};
 
 /// A point of interest in an image.
 /// This pretty much follows from OpenCV conventions.
@@ -53,7 +53,7 @@ pub struct Results {
 /// # Arguments
 /// * `input_image` - The image on which to draw.
 /// * `keypoints` - A vector of keypoints to draw.
-pub fn draw_keypoints_to_image(input_image: &mut RgbImage, keypoints: &Vec<Keypoint>) {
+pub fn draw_keypoints_to_image(input_image: &mut RgbImage, keypoints: &[Keypoint]) {
     for keypoint in keypoints.iter() {
         draw_circle(input_image, keypoint.point, random_color(), keypoint.size);
     }
@@ -69,7 +69,7 @@ pub fn draw_keypoints_to_image(input_image: &mut RgbImage, keypoints: &Vec<Keypo
 /// * `keypoints` - A vector of keypoints to draw.
 /// # Return value
 /// An new RGB image with keypoints drawn.
-pub fn draw_keypoints(input_image: &DynamicImage, keypoints: &Vec<Keypoint>) -> RgbImage {
+pub fn draw_keypoints(input_image: &DynamicImage, keypoints: &[Keypoint]) -> RgbImage {
     let mut rgb_image = input_image.to_rgb();
     draw_keypoints_to_image(&mut rgb_image, keypoints);
     rgb_image

--- a/tests/integration-test.rs
+++ b/tests/integration-test.rs
@@ -106,8 +106,8 @@ fn match_features() {
             let string_to_pass = val.to_string();
             let path_to_scale_space_dir = std::path::Path::new(&string_to_pass.clone()).to_owned();
             std::fs::create_dir_all(&string_to_pass.clone()).unwrap();
-            let mut input_image_0 = image::open(test_image_path_0.clone()).unwrap().to_rgb();
-            let mut input_image_1 = image::open(test_image_path_1.clone()).unwrap().to_rgb();
+            let input_image_0 = image::open(test_image_path_0.clone()).unwrap().to_rgb();
+            let input_image_1 = image::open(test_image_path_1.clone()).unwrap().to_rgb();
             let match_image = draw_matches(
                 &input_image_0,
                 &input_image_1,


### PR DESCRIPTION
 This PR fixes all the clippy lints (which allowed be to catch the hessian matrix calculation bug), updates the crate to Rust 2018, and fixes two bugs (see commits).

I will probably continue to work more on this crate in the future (there is a lot more refactoring, benchmarks, etc. to do). I would also like to use `ndarray` for the images somehow and to handle the various operations to get better abstraction and performance (although as noted in the code we need fast convolution) and potentially add SIMD support at some point. Convolution was [rejected](https://github.com/rust-ndarray/ndarray/issues/199) from `ndarray` core, but it is expected to be implemented as an extension crate, which I could do as part of a refactoring effort of this crate.

If you are interested I can take over maintainership, but if you are willing to continue to review PRs, merge them, and make releases then I would rather it stay off my plate so I can focus on refactoring/updating other various photogrammetry related Rust libraries.